### PR TITLE
Avoid duplicate requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predix-uaa-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Node module to get a token from UAA using client credentials or refresh tokens",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Node module to get a token from UAA using client credentials or refresh tokens",
   "main": "index.js",
   "scripts": {
-    "test": "mocha -R spec test/uaa.spec",
-    "coverage": "istanbul cover _mocha -- -R spec test/uaa.spec"
+    "test": "mocha -R spec test/uaa.spec.js",
+    "coverage": "istanbul cover _mocha -- -R spec test/uaa.spec.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Avoid redundant concurrent requests for the same client or refresh token
If multiple calls are made for the same client or refresh token, previously would blindly go fetch a new token for every call.  This wastes time and causes more tokens than necessary to be created (potentially costing money).
This update will keep track of pending duplicate requests and resolve them all with the same token, fetched only once.
