### PR TITLE
Added types hint in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "Node module to get a token from UAA using client credentials or refresh tokens",
   "main": "index.js",
+  "types":"./predix-uaa-client.d.ts",
   "scripts": {
     "test": "mocha -R spec test/uaa.spec.js",
     "coverage": "istanbul cover _mocha -- -R spec test/uaa.spec.js"

--- a/predix-uaa-client.d.ts
+++ b/predix-uaa-client.d.ts
@@ -6,6 +6,7 @@ declare module "predix-uaa-client" {
     export interface IToken {
         access_token: string;
         refresh_token: string;
-        expire_time: string;
+        expire_time: number;
+        renew_time: number;
     }
 }

--- a/predix-uaa-client.d.ts
+++ b/predix-uaa-client.d.ts
@@ -1,0 +1,11 @@
+declare module "predix-uaa-client" {
+    export function getToken(url: string, clientId: string, clientSecret: string, refreshToken?: string): Promise<IToken>;
+
+    export function clearCache();
+
+    export interface IToken {
+        access_token: string;
+        refresh_token: string;
+        expire_time: string;
+    }
+}


### PR DESCRIPTION
When using this from a sub-module of my app, I noticed it does not find the definition file through standard module resolution. After more research in the typescript doc, I found that it is suggested that the package.json contain a hint to the d.ts file.

Sorry I missed this with the initial PR.